### PR TITLE
Give app access to id-token if possible

### DIFF
--- a/pycloak/middleware.py
+++ b/pycloak/middleware.py
@@ -97,10 +97,10 @@ class JWTMiddleware(MiddlewareMixin):
         if user:
             request.session[conf.SESSION_KEY] = id_from_token
             if request.user != user:
-                logger.info("Different user, logging out")
+                logger.debug("Different user, logging out")
                 logout(request)
             if not request.user.is_authenticated:
-                logger.info("Logging user in", user=str(user))
+                logger.debug("Logging user in", user=str(user))
                 login(request, user)
             else:  # the same user with a new token
                 request.user = (


### PR DESCRIPTION
retrieve Authorization header to enable app access to the id-token if proxy is thus configured

e.g. in oauth2-proxy:
--pass-authorization-header true

will pass the id-token as Authorization Bearer token in addition to the access-token